### PR TITLE
feat: BL-18024 Remove old tapi documentation content

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -36,10 +36,6 @@
             <p>A new version of the MOT history API is available. You can <a
                     href="https://documentation.history.mot.api.gov.uk/" target="_blank">register to use the new API now (opens in new tab)</a>.</p>
         </div>
-        <div class="column-two-thirds">
-            <p> The old API will be turned off later this year. We’ll contact users before this happens. If you are using the old API, you’ll need to <a
-                    href="https://documentation.history.mot.api.gov.uk/" target="_blank">register to use the new MOT history API (opens in new tab)</a>.</p>
-        </div>
     </div>
 
     <div class="grid-row">


### PR DESCRIPTION
## Description

Within this ticket, we want to remove paragraph from the documentation which was informing user about switching off the API this year.

Related issue: [BL-18118](https://dvsa.atlassian.net/jira/software/c/projects/BL/boards/120?selectedIssue=BL-18118)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?

<img width="50%" alt="Screenshot 2024-11-20 at 14 18 18" src="https://github.com/user-attachments/assets/0a66351e-c246-4014-a84e-e4992841985d">

